### PR TITLE
add event propagation stop to delete click handler

### DIFF
--- a/client/src/components/ColorList.js
+++ b/client/src/components/ColorList.js
@@ -34,8 +34,12 @@ const ColorList = ({ colors, updateColors }) => {
         {colors.map(color => (
           <li key={color.color} onClick={() => editColor(color)}>
             <span>
-              <span className="delete" onClick={() => deleteColor(color)}>
-                x
+              <span className="delete" onClick={e => {
+                    e.stopPropagation();
+                    deleteColor(color)
+                  }
+                }>
+                  x
               </span>{" "}
               {color.color}
             </span>


### PR DESCRIPTION
The `span` for the red X has a click handler on it to delete the color. Selecting that looks to also trigger the click handler on the `li` element for the color as the event bubbles up. This makes the edit form appear for the color that has been deleted since the editing state changes from the `li` click handler. Using `e.stopPropagation()` on the delete click handler keeps that event from triggering the `editing ` state change.